### PR TITLE
Fa 62 replace btoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Breaks
 
 
+## 0.1.3 (2023-04-09)
+---
+
+### Changes
+Replace deprecated "btoa" with "Buffer" [FA-62].
+Use "Authorization: Bearer" instead of "x-access-tokens" in login [FA-67].
+Capitalized 'Token is invalid'
+
+
 ## 0.1.2 (2022-03-16)
 ---
 

--- a/src/_constants/general_constants.js
+++ b/src/_constants/general_constants.js
@@ -1,5 +1,5 @@
 // Security
-export const MSG_ERROR_INVALID_TOKEN = 'token is invalid';
+export const MSG_ERROR_INVALID_TOKEN = 'Token is invalid';
 export const MSG_ERROR_SESSION_EXPIRED = 'Session expired.';
 export const MSG_ERROR_CLICK_TO_RELOGIN = 'Click here to login again.';
 export const MSG_ERROR_CLICK_TO_RETRY = 'Click here to retry';

--- a/src/_helpers/auth-header.js
+++ b/src/_helpers/auth-header.js
@@ -5,8 +5,7 @@ export function authHeader() {
     const currentUser = authenticationService.currentUserValue;
     if (currentUser && currentUser.token) {
         return { Authorization: `Bearer ${currentUser.token}` };
-        // let headers = { 'x-access-tokens': currentUser.token };
-        // return headers;
+        // return { 'x-access-tokens': currentUser.token };
     } else {
         return {};
     }

--- a/src/_helpers/auth-header.js
+++ b/src/_helpers/auth-header.js
@@ -1,12 +1,12 @@
 import { authenticationService } from '../_services/db.authentication.service';
 
 export function authHeader() {
-    // return authorization header with jwt token
+    // Returns authorization header with jwt token
     const currentUser = authenticationService.currentUserValue;
     if (currentUser && currentUser.token) {
-        // return { Authorization: `Bearer ${currentUser.token}` };
-        let headers = { 'x-access-tokens': currentUser.token };
-        return headers;
+        return { Authorization: `Bearer ${currentUser.token}` };
+        // let headers = { 'x-access-tokens': currentUser.token };
+        // return headers;
     } else {
         return {};
     }

--- a/src/_services/db.authentication.service.js
+++ b/src/_services/db.authentication.service.js
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { console_debug_log } from './loging.service';
 import { authHeader } from '../_helpers/auth-header';
 import {
@@ -24,7 +25,11 @@ function login(username, password) {
     }
     const requestOptions = {
         method: 'POST',
-        headers: { "Authorization":  "Basic " + btoa(username + ":" + password) },
+        headers: {
+            "Authorization":  "Basic " + Buffer.from(
+                username + ":" + password
+            ).toString('base64')
+        },
     };
     let userService = new dbApiService({url: 'users'})
     return fetch(`${config.apiUrl}/users/login`, requestOptions)
@@ -125,7 +130,7 @@ export class dbApiService {
             {}, 
             { 
                 'Content-Type': 'application/json',
-                'Access-Control-Allow-Origin': '*'
+                'Access-Control-Allow-Origin': '*',
             }, 
             this.props.authHeader
         );
@@ -152,9 +157,13 @@ export class dbApiService {
     getAll(params=[]) {
         const requestOptions = { method: 'GET', headers: this.props.authHeader };
         const urlQuery = this.paramsToUrlQuery(params);
-        // console_debug_log('dbServices::getAll() - urlQuery: ');
-        // console_debug_log(urlQuery);
-        let response = fetch(`${this.apiUrl}/${this.props.url}${urlQuery}`, requestOptions)
+        const url = `${this.apiUrl}/${this.props.url}${urlQuery}`;
+console_debug_log('dbServices::getAll() - url: '+url);
+console_debug_log('dbServices::getAll() - urlQuery: ');
+console_debug_log(urlQuery);
+console_debug_log('dbServices::getAll() - requestOptions: ');
+console_debug_log(requestOptions);
+        let response = fetch(url, requestOptions)
                 .then(handleResponse, handleFetchError);
         return response;
     }


### PR DESCRIPTION
## 0.1.3 (2023-04-09)
---

### Changes
Replace deprecated "btoa" with "Buffer" [FA-62].
Use "Authorization: Bearer" instead of "x-access-tokens" in login [FA-67].
Capitalized 'Token is invalid'
